### PR TITLE
Add viewport meta tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,7 @@
       content="/images/favicon/browserconfig.xml"
     />
     <meta name="theme-color" content="#ffffff" />
+    <meta name="viewport" content="width=device-width, initial-scale=0.86, maximum-scale=1.0, minimum-scale=0.86">
     <link rel="stylesheet" href="./css/style.css" />
     <link
       href="https://cdn.quilljs.com/1.3.6/quill.snow.css"

--- a/public/index.html
+++ b/public/index.html
@@ -30,7 +30,7 @@
       content="/images/favicon/browserconfig.xml"
     />
     <meta name="theme-color" content="#ffffff" />
-    <meta name="viewport" content="width=device-width, initial-scale=0.86, maximum-scale=1.0, minimum-scale=0.86">
+    <meta name="viewport" content="width=device-width, initial-scale=0.86, maximum-scale=5.0, minimum-scale=0.86">
     <link rel="stylesheet" href="./css/style.css" />
     <link
       href="https://cdn.quilljs.com/1.3.6/quill.snow.css"


### PR DESCRIPTION
Fixes #10 

This commit adds a viewport tag to the <head> portion of the website.

According to my research, setting the initial-scale = 0.86 & the minimum-scale=0.86 will supress the zoom feature that phones have and scale it up to make it viewable on the device.

Let me know what you think @jrobind 

Cool project by the way!