### PR TITLE
#Issue #45 | Exit button padding fix

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -365,6 +365,7 @@ body {
 }
 
 .lesson-card-title-container {
+  margin-bottom: 10px;
   display: flex;
   justify-content: space-between;
 }


### PR DESCRIPTION
Fixed exit button padding. 
It's now set 10px from top/right and bottom and looks fine.