### PR TITLE
Fix lesson display

### DIFF
--- a/app-main/public/css/style.css
+++ b/app-main/public/css/style.css
@@ -55,7 +55,7 @@ body {
 .modal,
 .modal-lesson {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   position: fixed;
   top: 50%;
@@ -107,15 +107,13 @@ body {
   max-width: 1050px;
   width: 95%;
   max-height: calc(100vh - 250px);
-  
 }
 
 .modal-lesson-title {
-  margin-top: 50px;
-  padding: 15px;
- 
   font-size: 32px;
   position: relative;
+  margin:25px;
+  width: 95%;
 }
 
 .modal-lesson-title::before {
@@ -123,15 +121,13 @@ body {
   position: absolute;
   width:100%;
   height: 20px;
-  right: 10px;
-  top: 40px;
+  top: 25px;
   z-index: -1;
   background-color: var(--tertiary-b-color);
   opacity: 50%;
 }
 
 .modal-lesson-content {
-  
   width: 95%;
   overflow: auto;
   border: 1px solid rgba(0, 0, 0, 0.15);

--- a/app-main/public/css/style.css
+++ b/app-main/public/css/style.css
@@ -133,7 +133,6 @@ body {
   overflow: auto;
   border: 1px solid rgba(0, 0, 0, 0.15);
   border-radius: 3px;
-  margin-bottom: 15px;
   margin: 0 auto 30px auto;
 }
 

--- a/app-main/public/css/style.css
+++ b/app-main/public/css/style.css
@@ -105,17 +105,15 @@ body {
 
 .modal-lesson {
   max-width: 1050px;
-  width: 100%;
+  width: 95%;
   max-height: calc(100vh - 250px);
-  padding: 5px;
-  overflow: auto;
-  justify-content: flex-start;
+  
 }
 
 .modal-lesson-title {
   margin-top: 50px;
-  align-self: flex-start;
-  padding: 15px 60px;
+  padding: 15px;
+ 
   font-size: 32px;
   position: relative;
 }
@@ -123,9 +121,9 @@ body {
 .modal-lesson-title::before {
   content: "";
   position: absolute;
-  width: calc(100% - 100px);
+  width:100%;
   height: 20px;
-  left: 50px;
+  right: 10px;
   top: 40px;
   z-index: -1;
   background-color: var(--tertiary-b-color);
@@ -133,8 +131,10 @@ body {
 }
 
 .modal-lesson-content {
-  padding: 15px 60px;
-  align-self: flex-start;
+  
+  width: 95%;
+  overflow: auto;
+  border: 1px solid rgba(0, 0, 0, 0.15);
 }
 
 /* header styles */

--- a/app-main/public/css/style.css
+++ b/app-main/public/css/style.css
@@ -131,6 +131,7 @@ body {
   width: 95%;
   overflow: auto;
   border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 3px;
 }
 
 /* header styles */

--- a/app-main/public/css/style.css
+++ b/app-main/public/css/style.css
@@ -112,9 +112,7 @@ body {
 .modal-lesson-title {
   font-size: 32px;
   position: relative;
-  margin:60px 30px;
-  
-  
+  margin:60px 30px 10px 30px;
 }
 
 .modal-lesson-title::before {
@@ -128,7 +126,6 @@ body {
   /* the stylized offset */
   width: calc(100% + 18px);
   right: -8px;
-  
 }
 
 .modal-lesson-content {

--- a/app-main/public/css/style.css
+++ b/app-main/public/css/style.css
@@ -56,7 +56,7 @@ body {
 .modal-lesson {
   display: flex;
   justify-content: flex-start;
-  align-items: center;
+  align-items: flex-start;
   position: fixed;
   top: 50%;
   right: 50%;
@@ -112,19 +112,23 @@ body {
 .modal-lesson-title {
   font-size: 32px;
   position: relative;
-  margin:25px;
-  width: 95%;
+  margin:60px 30px;
+  
+  
 }
 
 .modal-lesson-title::before {
   content: "";
   position: absolute;
-  width:100%;
   height: 20px;
   top: 25px;
   z-index: -1;
   background-color: var(--tertiary-b-color);
   opacity: 50%;
+  /* the stylized offset */
+  width: calc(100% + 18px);
+  right: -8px;
+  
 }
 
 .modal-lesson-content {
@@ -132,6 +136,8 @@ body {
   overflow: auto;
   border: 1px solid rgba(0, 0, 0, 0.15);
   border-radius: 3px;
+  margin-bottom: 15px;
+  margin: 0 auto 30px auto;
 }
 
 /* header styles */

--- a/app-main/public/index.html
+++ b/app-main/public/index.html
@@ -47,11 +47,12 @@
       <button hidden class="sign-in">Sign in with Google</button>
     </div>
     <div hidden class="modal modal-lesson">
-      <h2 class="modal-lesson-title"></h2>
-      <div class="modal-lesson-content"></div>
       <button class="modal-lesson-close button">
         <img alt="remove lesson icon" src="./images/cancel-white.svg" />
       </button>
+      <h2 class="modal-lesson-title"></h2>
+      <div class="ql-editor modal-lesson-content">
+      </div>
     </div>
     <header class="header">
       <div class="header-title">


### PR DESCRIPTION
**The initial issue was that the selected font size was not being applied when viewing the lesson modal.** 

- The original issue was fixed by adding the "ql-editor" class to modal-lesson-content div in index.html, this is necessary when using the "ql-size" classes as all of the sizing selectors in the quill style sheet select by using both classes.

- After observing another issue where the close(X button) was scrolling away and becoming hidden inside the view modal, I rearranged the view container to better separate the content from the title and X button. 

- Fixed all the style issues in the modal content caused by rearranging the HTML and adding the ql-editor class.

- Further, I redesigned the view lesson modal to be more responsive and dealt with a few superfluous rules. 