### PR TITLE
styling fix for content extending beyond bounds of lesson view

### DIFF
--- a/app-main/public/css/style.css
+++ b/app-main/public/css/style.css
@@ -91,7 +91,7 @@ body {
 .modal-lesson {
   max-width: 1050px;
   width: 95%;
-  max-height: calc(100vh - 250px);
+  max-height: 80vh;
 }
 .modal-lesson-title {
   font-size: 32px;
@@ -119,6 +119,7 @@ body {
   border: 1px solid rgba(0, 0, 0, 0.15);
   border-radius: 3px;
   margin: 0 0 30px 0;
+  height: 60vh !important;
 }
 
 .modal-lesson-body {


### PR DESCRIPTION
overflow-y was already enabled so I added these two lines to make sure that the note content doesn't extend beyond the bounds of the container. 