### PR TITLE
Removed Tabtrap in lesson editor

### DIFF
--- a/app-main/public/js/quill_init.js
+++ b/app-main/public/js/quill_init.js
@@ -13,3 +13,4 @@ export const quill = new Quill("#editor", {
   placeholder: "Add some lesson notes!",
   theme: "snow",
 });
+delete quill.getModule('keyboard').bindings["9"]


### PR DESCRIPTION
Removed Tabtrap in the lesson editor
Works with both "tab" and "shift+tab"
closes #2 